### PR TITLE
Navigate to word details from history screen

### DIFF
--- a/app/src/main/java/com/rodcollab/lingoleap/HistoryScreen.kt
+++ b/app/src/main/java/com/rodcollab/lingoleap/HistoryScreen.kt
@@ -20,7 +20,7 @@ import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 
 @Composable
-fun HistoryScreen(modifier: Modifier, viewModel: HistoryViewModel = hiltViewModel()) {
+fun HistoryScreen(modifier: Modifier, toDetailsScreen: (String) -> Unit, viewModel: HistoryViewModel = hiltViewModel()) {
 
     val state by viewModel.state.collectAsState()
 
@@ -34,7 +34,7 @@ fun HistoryScreen(modifier: Modifier, viewModel: HistoryViewModel = hiltViewMode
             items(state.list) { word ->
                 SearchWordItem(
                     wordItemUiState = word,
-                    onClick = {},
+                    toDetailsScreen = toDetailsScreen,
                     modifier = Modifier.fillMaxWidth()
                 )
             }
@@ -45,7 +45,7 @@ fun HistoryScreen(modifier: Modifier, viewModel: HistoryViewModel = hiltViewMode
 @Composable
 fun SearchWordItem(
     wordItemUiState: SearchedWordItemState,
-    onClick: () -> Unit,
+    toDetailsScreen: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
 
@@ -54,7 +54,7 @@ fun SearchWordItem(
         modifier = modifier
             .fillMaxWidth()
             .background(MaterialTheme.colors.surface)
-            .clickable { onClick() },
+            .clickable { toDetailsScreen(wordItemUiState.name) },
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically
     ) {

--- a/app/src/main/java/com/rodcollab/lingoleap/MainActivity.kt
+++ b/app/src/main/java/com/rodcollab/lingoleap/MainActivity.kt
@@ -58,6 +58,9 @@ class MainActivity : ComponentActivity() {
                                 modifier = Modifier
                                     .fillMaxSize()
                                     .padding(paddingValues),
+                                toDetailsScreen = { word ->
+                                    navController.navigate("word_details/$word")
+                                },
                             )
                         }
                         composable("profile") {


### PR DESCRIPTION
## What is the Purpose of this Pull Request (PR)?

- The user should be able to click on an item on the History Screen and navigate to the Word Details Screen.

## Technical Details
- The word is passed as an argument and then retrieved using SavedStateHandle.